### PR TITLE
Extended globalName using pure String

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 *.log
-/template.js

--- a/README.md
+++ b/README.md
@@ -43,20 +43,21 @@ Starting from 0.2.0, you can use extended `deps` syntax for setting custom names
 [
     {name: 'jquery', globalName: 'jQuery', paramName: '$' /* , cjsName: ..., amdName: ... */},
     'jade',
-    {name: 'lodash', globalName: '_', amdName: '../lodash'}
+    {name: 'lodash', globalName: '_', amdName: '../lodash'},
+    {name: 'angular-cookies', globalName: "'ngCookies'", globalNameString: true, paramName: 'ngCookies'}
 ]
 ```
 ...so you would get:
 ```javascript
 (function(root, factory) {
     if (typeof define === 'function' && define.amd) {
-        define(["jquery", "jade", "../lodash"], factory);
+        define(["jquery", "jade", "../lodash", "angular-cookies"], factory);
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('jquery'), require('jade'), require('lodash'));
+        module.exports = factory(require('jquery'), require('jade'), require('lodash'), require('angular-cookies'));
     } else {
-        root.test = factory(root.jQuery, root.jade, root._);
+        root.test = factory(root.jQuery, root.jade, root._, 'ngCookies');
     }
-}(this, function($, jade, _) {
+}(this, function($, jade, _, ngCookies) {
     // ...
 }));
 ```
@@ -67,6 +68,7 @@ Starting from 0.2.0, you can use extended `deps` syntax for setting custom names
 {
   name: '' // default name for any properties that aren't set
   globalName: '', // global namespace to attach to
+  globalNameString: false, // True set globalName string format
   paramName: '', // parameter name for the wrapper function
   amdName: ''; // module name for the AMD dependency
   cjsName: ''; // module name for the CJS dependency

--- a/index.js
+++ b/index.js
@@ -16,12 +16,14 @@ function normalizeDeps(deps, params){
     if(typeof dep === 'string'){
       out.name = dep;
       out.globalName = dep;
+      out.globalNameString = false;
       out.paramName = paramName();
       out.amdName = dep;
       out.cjsName = dep;
     } else {
       out.name = dep.name;
       out.globalName = dep.globalName || dep.name;
+      out.globalNameString = dep.globalNameString || false;
       out.paramName = dep.paramName || paramName();
       out.amdName = dep.amdName || dep.name;
       out.cjsName = dep.cjsName || dep.name;

--- a/template.js
+++ b/template.js
@@ -1,0 +1,72 @@
+;(function() {
+  var undefined;
+
+  var objectTypes = {
+    'function': true,
+    'object': true
+  };
+
+  var root = (objectTypes[typeof window] && window) || this;
+
+  var freeExports = objectTypes[typeof exports] && exports && !exports.nodeType && exports;
+
+  var freeModule = objectTypes[typeof module] && module && !module.nodeType && module
+
+  var moduleExports = freeModule && freeModule.exports === freeExports && freeExports;
+
+  var freeGlobal = objectTypes[typeof global] && global;
+  if (freeGlobal && (freeGlobal.global === freeGlobal || freeGlobal.window === freeGlobal)) {
+    root = freeGlobal;
+  }
+
+  var _ = root._;
+
+  var templates = {};
+
+  templates['umd'] = function(obj) {
+    obj || (obj = {});
+    var __t, __p = '', __e = _.escape, __j = Array.prototype.join;
+    function print() { __p += __j.call(arguments, '') }
+    with (obj) {
+
+    var stdDeps = ['require', 'exports', 'module'];
+
+    var amdDeps = _.pluck(deps, 'amdName');
+    var globalDeps = _.map(deps, function(dep) { return dep.globalNameString ? dep.globalName : 'root.' + dep.globalName });
+    var cjsDeps = deps ? _.map(deps, function(dep) { return "require('" + dep.cjsName + "')" }) : stdDeps;
+    var depNames = deps ? _.pluck(deps, 'paramName') : stdDeps;
+    __p += '\n(function(root, factory) {\n  if (typeof define === \'function\' && define.amd) {\n    define(' +
+    ((__t = ( deps ? JSON.stringify(amdDeps) + ', ' : '' )) == null ? '' : __t) +
+    'factory);\n  } else if (typeof exports === \'object\') {\n    module.exports = factory(' +
+    ((__t = ( cjsDeps.join(', ') )) == null ? '' : __t) +
+    ');\n  } else {\n    root.' +
+    ((__t = ( namespace )) == null ? '' : __t) +
+    ' = factory(' +
+    ((__t = ( globalDeps.join(', ') )) == null ? '' : __t) +
+    ');\n  }\n}(this, function(' +
+    ((__t = ( depNames.join(', ') )) == null ? '' : __t) +
+    ') {\n';
+     if (exports) {
+    __p += '\n' +
+    ((__t = ( contents )) == null ? '' : __t) +
+    '\nreturn ' +
+    ((__t = ( exports )) == null ? '' : __t) +
+    ';\n';
+     } else {
+    __p += '\nreturn ' +
+    ((__t = ( contents )) == null ? '' : __t) +
+    ';\n';
+     }
+    __p += '\n}));\n';
+
+    }
+    return __p
+  };
+
+  if (freeExports && freeModule) {
+    _ = require('lodash');
+    if (moduleExports) {
+      (freeModule.exports = templates).templates = templates;
+    }
+  }
+}.call(this));

--- a/templates/umd.jst
+++ b/templates/umd.jst
@@ -2,7 +2,7 @@
 var stdDeps = ['require', 'exports', 'module'];
 
 var amdDeps = _.pluck(deps, 'amdName');
-var globalDeps = _.map(deps, function(dep) { return 'root.' + dep.globalName });
+var globalDeps = _.map(deps, function(dep) { return dep.globalNameString ? dep.globalName : 'root.' + dep.globalName });
 var cjsDeps = deps ? _.map(deps, function(dep) { return "require('" + dep.cjsName + "')" }) : stdDeps;
 var depNames = deps ? _.pluck(deps, 'paramName') : stdDeps;
 %>

--- a/test/test.js
+++ b/test/test.js
@@ -91,16 +91,18 @@ test('should wrap a function in UMD wrapper using extended deps syntax', functio
       deps: [
         {name: 'jquery', globalName: 'jQuery'},
         'jade',
-        {name: 'lodash', globalName: '_', amdName: '../lodash'}
+        {name: 'lodash', globalName: '_', amdName: '../lodash'},
+        {name: 'angular-cookies', globalName: '"ngCookies"', globalNameString: true}
       ],
-      params: ['$', 'jade', '_'],
+      params: ['$', 'jade', '_', 'ngCookies'],
       namespace: 'test'
     }))
     .pipe(expectStream(t, {
       deps: [
         {name: 'jquery', amdName: 'jquery', cjsName: 'jquery', globalName: 'jQuery', paramName: '$'},
         {name: 'jade', amdName: 'jade', cjsName: 'jade', globalName: 'jade', paramName: 'jade'},
-        {name: 'lodash', amdName: '../lodash', cjsName: 'lodash', globalName: '_', paramName: '_'}
+        {name: 'lodash', amdName: '../lodash', cjsName: 'lodash', globalName: '_', paramName: '_'},
+        {name: 'angular-cookies', amdName: 'angular-cookies', cjsName: 'angular-cookies', globalName: '"ngCookies"', globalNameString: true, paramName: 'ngCookies'}
       ],
       namespace: 'test'
     }));


### PR DESCRIPTION
In some AngularJS project global inject Name is pure String.

For Example:

``` js
factory(root.angular, "ngCookies")
```

but the template in this project is always generate `root. + <moduleName>`, so I want to pull request 😄 
